### PR TITLE
新しいハッシュタグがトレンドに掲載されたとき、NEW を文字じゃなくて絵文字で報告するようにした

### DIFF
--- a/main.php
+++ b/main.php
@@ -127,7 +127,7 @@ foreach ( $trend_tags_result['score'] as $current_tag_text => $current_tag_score
 		}
 		else {
 			// 存在しない場合はこちら
-			$score_movement = 'NEW';
+			$score_movement = '🆕';
 			// 新しいタグがトレンドに新規掲載になったので、トゥート必要
 			$rank_diff = TRUE;
 		}


### PR DESCRIPTION
トレンドタグを報告する際、リストに前回掲載されていなかった新しいハッシュタグがリストアップされると、スコア変化を示す部分に [NEW] を表示していました。
絵文字に :new: が存在するので、これを使うように変更します。他に使用している絵文字 :hash: :arrow_upper_right: :arrow_lower_right: との統一感もあります。